### PR TITLE
Change data loading paths: CINIC-10

### DIFF
--- a/fp16util.py
+++ b/fp16util.py
@@ -1,0 +1,43 @@
+import torch
+import torch.nn as nn
+
+
+class tofp16(nn.Module):
+    def __init__(self):
+        super(tofp16, self).__init__()
+
+    def forward(self, input):
+        return input.half()
+
+
+def copy_in_params(net, params):
+    net_params = list(net.parameters())
+    for i in range(len(params)):
+        net_params[i].data.copy_(params[i].data)
+
+
+def set_grad(params, params_with_grad):
+
+    for param, param_w_grad in zip(params, params_with_grad):
+        if param.grad is None:
+            param.grad = torch.nn.Parameter(param.data.new().resize_(*param.data.size()))
+        param.grad.data.copy_(param_w_grad.grad.data)
+
+
+def BN_convert_float(module):
+    '''
+    BatchNorm layers to have parameters in single precision.
+    Find all layers and convert them back to float. This can't
+    be done with built in .apply as that function will apply
+    fn to all modules, parameters, and buffers. Thus we wouldn't
+    be able to guard the float conversion based on the module type.
+    '''
+    if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+        module.float()
+    for child in module.children():
+        BN_convert_float(child)
+    return module
+
+
+def network_to_half(network):
+    return nn.Sequential(tofp16(), BN_convert_float(network.half()))


### PR DESCRIPTION
CINIC-10 dataset: [https://datashare.is.ed.ac.uk/handle/10283/3192](url)


There are certain changes on `main.py` file. The first change is on data loading directory to CINIC-10 dataset folder
```python
cinic_dir = 'CINIC-10'
trainset = torchvision.datasets.ImageFolder(cinic_dir + '/train', transform=transform_train)
trainloader = torch.utils.data.DataLoader(trainset, batch_size=128, shuffle=True, num_workers=5)

testset = torchvision.datasets.ImageFolder(cinic_dir + '/test', transform=transform_test)
testloader = torch.utils.data.DataLoader(testset, batch_size=80, shuffle=False, num_workers=5)

classes = ('airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
```

Next, to adjust with CINIC-10 dataset, transform normalize value has been changed as
```python
cinic_mean = [0.47889522, 0.47227842, 0.43047404]
cinic_std = [0.24205776, 0.23828046, 0.25874835]

transform_train = transforms.Compose([
    transforms.RandomCrop(32, padding=1),
    transforms.RandomHorizontalFlip(),
    transforms.ToTensor(),
    transforms.Normalize(cinic_mean, cinic_std),
])

transform_test = transforms.Compose([
    transforms.ToTensor(),
    transforms.Normalize(cinic_mean, cinic_std),
])
```

Lastly, the learning rate which is used in this training is `lr = 0.01`

